### PR TITLE
Fix YouTube download flow and enforce H.264

### DIFF
--- a/web-interface/README.md
+++ b/web-interface/README.md
@@ -142,8 +142,9 @@ define('GLANCES_URL', 'http://localhost:61208');
 - Services : vlc-signage, chromium-kiosk, nginx, glances
 
 ### `/api/youtube.php`
-- Télécharge des vidéos YouTube
-- Retourne la progression en temps réel
+- Télécharge une vidéo YouTube pour l'utilisateur connecté
+- Envoyer `csrf_token` et `url` via POST JSON
+- Retourne `{success: bool, message?: string}`
 
 ## 💻 Développement
 

--- a/web-interface/api/youtube.php
+++ b/web-interface/api/youtube.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * API de téléchargement YouTube
+ */
+
+define('PI_SIGNAGE_WEB', true);
+require_once '../includes/config.php';
+require_once '../includes/auth.php';
+require_once '../includes/functions.php';
+require_once '../includes/security.php';
+
+if (!isAuthenticated()) {
+    http_response_code(401);
+    exit(json_encode(['success' => false, 'message' => 'Unauthorized']));
+}
+
+setSecurityHeaders();
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    exit(json_encode(['success' => false, 'message' => 'Method not allowed']));
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+
+if (!validateCSRFToken($input['csrf_token'] ?? '')) {
+    http_response_code(403);
+    exit(json_encode(['success' => false, 'message' => 'CSRF token validation failed']));
+}
+
+$url = $input['url'] ?? '';
+$title = $input['title'] ?? null;
+
+$result = downloadYouTubeVideo($url, $title);
+
+echo json_encode($result);

--- a/web-interface/assets/js/main.js
+++ b/web-interface/assets/js/main.js
@@ -213,6 +213,7 @@ function downloadYouTube() {
     const urlInput = document.getElementById('youtube-url');
     const downloadBtn = document.getElementById('download-btn');
     const progressDiv = document.getElementById('download-progress');
+    const csrfToken = document.querySelector('#youtube-form input[name="csrf_token"]').value;
     
     if (!urlInput || !urlInput.value) {
         showNotification('Veuillez entrer une URL YouTube', 'warning');
@@ -228,7 +229,7 @@ function downloadYouTube() {
         headers: {
             'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ url: urlInput.value })
+        body: JSON.stringify({ url: urlInput.value, csrf_token: csrfToken })
     })
     .then(response => response.json())
     .then(data => {

--- a/web-interface/includes/config.template.php
+++ b/web-interface/includes/config.template.php
@@ -20,6 +20,8 @@ define('VIDEO_DIR', '/opt/videos');
 define('SCRIPTS_DIR', '/opt/scripts');
 define('LOG_DIR', '/var/log/pi-signage');
 define('WEB_ROOT', dirname(__DIR__));
+// binaire yt-dlp
+define('YTDLP_BIN', '/usr/local/bin/yt-dlp');
 
 // Mode d'affichage
 if (file_exists('/etc/pi-signage/display-mode.conf')) {

--- a/web-interface/includes/functions.php
+++ b/web-interface/includes/functions.php
@@ -196,10 +196,18 @@ function downloadYouTubeVideo($url, $title = null) {
     // Construire la commande yt-dlp
     $output_path = VIDEO_DIR . '/' . $filename . '.%(ext)s';
     $cmd = sprintf(
-        'yt-dlp -f "best[ext=mp4]/best" -o %s --no-playlist --restrict-filenames %s 2>&1',
+        '%s -f "best[ext=mp4]/best" -o %s --no-playlist --restrict-filenames %s',
+        escapeshellcmd(YTDLP_BIN),
         escapeshellarg($output_path),
         escapeshellarg($url)
     );
+
+    // Forcer H.264 en mode Chromium
+    if (DISPLAY_MODE === 'chromium') {
+        $cmd .= ' --recode-video mp4 --postprocessor-args "-c:v libx264 -preset fast -crf 23 -c:a aac -b:a 128k -movflags +faststart"';
+    }
+
+    $cmd .= ' 2>&1';
     
     // Exécuter la commande
     $output = shell_exec($cmd);

--- a/web-interface/public/videos.php
+++ b/web-interface/public/videos.php
@@ -100,10 +100,7 @@ $diskSpace = checkDiskSpace();
                     <hr style="margin: 2rem 0;">
                     
                     <h3>Télécharger depuis YouTube</h3>
-                    <p>Téléchargez des vidéos directement depuis YouTube.</p>
-                    <a href="youtube-simple.php" class="btn btn-primary">
-                        📥 Télécharger depuis YouTube
-                    </a>
+                    <p>Utilisez le formulaire en bas de page pour importer une vidéo.</p>
                 </div>
             </div>
         </div>

--- a/web-interface/public/youtube-simple.php
+++ b/web-interface/public/youtube-simple.php
@@ -32,10 +32,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['url'])) {
             
             // Commande yt-dlp
             $cmd = sprintf(
-                'yt-dlp -f "best[ext=mp4]/best" -o %s --no-playlist "%s" 2>&1',
+                '%s -f "best[ext=mp4]/best" -o %s --no-playlist %s',
+                escapeshellcmd(YTDLP_BIN),
                 escapeshellarg($output_path),
-                $url
+                escapeshellarg($url)
             );
+
+            if (DISPLAY_MODE === 'chromium') {
+                $cmd .= ' --recode-video mp4 --postprocessor-args "-c:v libx264 -preset fast -crf 23 -c:a aac -b:a 128k -movflags +faststart"';
+            }
+
+            $cmd .= ' 2>&1';
             
             // Exécuter (avec timeout de 5 minutes)
             set_time_limit(300);


### PR DESCRIPTION
## Summary
- introduce `YTDLP_BIN` constant in configuration
- use `YTDLP_BIN` and force H.264 when downloading videos
- add `/api/youtube.php` endpoint
- update JavaScript with CSRF token handling
- clean up YouTube download link in videos page
- document new API behaviour

## Testing
- `find . -name "*.sh" -exec bash -n {} \;`
- `find web-interface -name "*.php" -exec php -l {} \;`

------
https://chatgpt.com/codex/tasks/task_e_686206a335b08326ba23b43f7a576a8b