### PR TITLE
Apply youtube compatibility patch in web interface install

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ L'installation est **modulaire** - vous pouvez choisir :
 - ✅ **Dashboard moderne** : Vue d'ensemble en temps réel
 - ✅ **Gestion des vidéos** : Upload, suppression, organisation
 - ✅ **Téléchargement YouTube** : Via yt-dlp (vos propres vidéos)
+- ✅ **Compatibilité Chromium** : le patch `yt-dlp-chromium` est appliqué automatiquement après le déploiement de l'interface web
 - ✅ **Monitoring système** : CPU, RAM, température, stockage
 - ✅ **Contrôle à distance** : Démarrer/arrêter les services
 - ✅ **Page paramètres** : Gestion des services et configuration système

--- a/raspberry-pi-installer/docs/CHROMIUM_KIOSK_GUIDE.md
+++ b/raspberry-pi-installer/docs/CHROMIUM_KIOSK_GUIDE.md
@@ -37,6 +37,7 @@ Le mode Chromium Kiosk est une alternative moderne et légère au mode VLC Class
 
 ### Compatibilité YouTube
 Le système télécharge automatiquement les vidéos YouTube en **H.264/MP4** compatible grâce au wrapper `yt-dlp-chromium`.
+Ce patch est appliqué automatiquement dès que l'interface web est installée.
 
 ## 🚀 Installation
 

--- a/raspberry-pi-installer/scripts/03-chromium-kiosk.sh
+++ b/raspberry-pi-installer/scripts/03-chromium-kiosk.sh
@@ -1087,7 +1087,6 @@ main() {
         "configure_x11_minimal"
         "optimize_chromium"
         "create_admin_scripts"
-        "ensure_youtube_compatibility"
     )
     
     local failed_steps=()

--- a/raspberry-pi-installer/scripts/09-web-interface-v2.sh
+++ b/raspberry-pi-installer/scripts/09-web-interface-v2.sh
@@ -663,7 +663,12 @@ main() {
     # Validation
     if validate_web_installation; then
         log_info "Interface web installée avec succès"
-        
+
+        local youtube_patch="$SCRIPT_DIR/patches/youtube-chromium-compatibility.sh"
+        if [[ $DISPLAY_MODE == "chromium" && -f "$youtube_patch" ]]; then
+            bash "$youtube_patch"
+        fi
+
         # Afficher les informations d'accès
         local ip_addr
         ip_addr=$(hostname -I | awk '{print $1}' 2>/dev/null || echo "IP_ADDRESS")


### PR DESCRIPTION
## Summary
- apply youtube patch after validating web interface install
- update docs about automatic youtube patching
- remove youtube compatibility step from chromium kiosk setup

## Testing
- `find . -name "*.sh" -exec bash -n {} \;`
- `find web-interface -name "*.php" -exec php -l {} \;`

------
https://chatgpt.com/codex/tasks/task_e_68628cbe837483269442a473f87f249c