### PR TITLE
Fix docs referencing removed orchestrators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Pages web manquantes** :
   - `videos.php` : Interface complète de gestion vidéos avec upload et YouTube
   - `settings.php` : Page de paramètres système avec contrôle services
-- **Script `main_orchestrator_v2.sh`** : Nouveau script principal avec sélection du mode d'affichage
+- **Script `install.sh`** : Nouveau point d'entrée avec sélection du mode d'affichage
 - **Comparaison interactive** : Aide au choix entre VLC et Chromium lors de l'installation
 - **Scripts d'administration Chromium** :
   - `player-control.sh` : Contrôle du player (play, pause, next, etc.)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,7 +40,7 @@ chmod +x *.sh
 
 ```bash
 # Lancer le script d'installation principal
-sudo ./main_orchestrator_v2.sh
+sudo ./install.sh
 ```
 
 ### 4. Suivre l'assistant
@@ -83,7 +83,7 @@ Pour les tests sur machine virtuelle (QEMU, UTM, VirtualBox) :
 ```bash
 # L'installation détecte automatiquement l'environnement VM
 # et installe Xvfb pour le support headless
-sudo ./main_orchestrator_v2.sh
+sudo ./install.sh
 
 # Le mode VM est activé automatiquement si détecté
 ```
@@ -143,7 +143,7 @@ sudo journalctl -f
 ```bash
 # Nettoyer l'environnement
 unset LOG_FILE CONFIG_FILE
-sudo ./main_orchestrator_v2.sh
+sudo ./install.sh
 ```
 
 ### Services non démarrés

--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ Pi-Signage/
 │   │   ├── 08-backup-manager.sh # Gestion des sauvegardes
 │   │   ├── 09-web-interface-v2.sh # Interface web (nouvelle version)
 │   │   ├── 10-final-check.sh    # Vérification finale
-│   │   ├── main_orchestrator.sh  # Script principal v2.2
-│   │   └── main_orchestrator_v2.sh # Script principal v2.3 (nouveau!)
+│   │   └── install.sh           # Script principal d'installation
 │   ├── docs/                    # Documentation technique
 │   └── examples/                # Fichiers de configuration exemple
 │
@@ -83,7 +82,7 @@ cd Pi-Signage/raspberry-pi-installer/scripts
 chmod +x *.sh
 
 # Lancer l'installation v2.3.0
-sudo ./main_orchestrator_v2.sh
+sudo ./install.sh
 ```
 
 #### Installation sur VM/Headless pour tests
@@ -95,7 +94,7 @@ cd Pi-Signage/raspberry-pi-installer/scripts
 
 # Installation avec support Xvfb automatique
 chmod +x *.sh
-sudo ./main_orchestrator_v2.sh
+sudo ./install.sh
 
 # Le script détecte automatiquement l'environnement VM et installe Xvfb
 ```
@@ -106,10 +105,10 @@ Si vous obtenez l'erreur "variable en lecture seule" :
 ```bash
 # Option 1 : Nettoyer l'environnement
 unset LOG_FILE CONFIG_FILE
-sudo ./main_orchestrator_v2.sh
+sudo ./install.sh
 
 # Option 2 : Utiliser un nouveau shell
-sudo bash ./main_orchestrator_v2.sh
+sudo bash ./install.sh
 ```
 
 #### Modes d'affichage disponibles (nouveau!)

--- a/pi-signage-web-readme.md
+++ b/pi-signage-web-readme.md
@@ -42,8 +42,8 @@ L'interface web Pi Signage offre une gestion complète du système de digital si
 # Le module 09 installe automatiquement tout
 sudo ./09-web-interface.sh
 
-# Ou via l'orchestrateur principal
-sudo ./main_orchestrator.sh
+# Ou via le script principal
+sudo ./install.sh
 ```
 
 ### Installation manuelle

--- a/raspberry-pi-installer/MIGRATION.md
+++ b/raspberry-pi-installer/MIGRATION.md
@@ -37,7 +37,7 @@ Pi-Signage/
    # Option 1 : Renommer simplement
    mv 09-web-interface-v2.sh 09-web-interface.sh
    
-   # Option 2 : Modifier main_orchestrator.sh pour utiliser v2
+   # Option 2 : Utiliser le nouveau script install.sh
    ```
 
 2. **Le nouveau script va automatiquement**

--- a/raspberry-pi-installer/docs/CHROMIUM_KIOSK_GUIDE.md
+++ b/raspberry-pi-installer/docs/CHROMIUM_KIOSK_GUIDE.md
@@ -48,7 +48,7 @@ git clone https://github.com/elkir0/Pi-Signage.git
 cd Pi-Signage/raspberry-pi-installer/scripts
 
 # Lancer l'installation v2.3
-sudo ./main_orchestrator_v2.sh
+sudo ./install.sh
 
 # Choisir "2) Chromium Kiosk" quand demandé
 ```

--- a/raspberry-pi-installer/docs/README.md
+++ b/raspberry-pi-installer/docs/README.md
@@ -98,7 +98,7 @@ pi-signage.target                # Target principal groupant tous les services
    chmod +x *.sh
    
    # Lancer l'installation v2.3.0
-   sudo ./main_orchestrator_v2.sh
+   sudo ./install.sh
    ```
 
 2. **Suivre l'assistant d'installation :**
@@ -124,7 +124,7 @@ pi-signage.target                # Target principal groupant tous les services
 
 ```bash
 # 1. Script principal
-sudo ./main_orchestrator_v2.sh
+sudo ./install.sh
 
 # 2. Modules individuels (si besoin)
 sudo ./00-security-utils.sh
@@ -146,7 +146,7 @@ sudo ./10-final-check.sh
 ```bash
 # Le script détecte automatiquement l'environnement VM
 # et installe Xvfb si nécessaire
-sudo ./main_orchestrator_v2.sh
+sudo ./install.sh
 
 # Pour forcer le mode VM manuellement
 touch /etc/pi-signage/vm-mode.conf

--- a/raspberry-pi-installer/docs/troubleshooting.md
+++ b/raspberry-pi-installer/docs/troubleshooting.md
@@ -22,7 +22,7 @@ Ce guide vous aidera à résoudre les problèmes courants rencontrés avec Pi Si
 ```bash
 # Si vous avez une ancienne version, mettez à jour :
 git pull origin main
-sudo ./main_orchestrator_v2.sh
+sudo ./install.sh
 ```
 
 ### Erreur "readonly variable" lors de l'installation
@@ -33,10 +33,10 @@ sudo ./main_orchestrator_v2.sh
 ```bash
 # Option 1 : Nettoyer l'environnement
 unset LOG_FILE CONFIG_FILE SCRIPT_DIR
-sudo ./main_orchestrator_v2.sh
+sudo ./install.sh
 
 # Option 2 : Utiliser un nouveau shell
-sudo bash ./main_orchestrator_v2.sh
+sudo bash ./install.sh
 ```
 
 ### Installation sur VM/Headless - Pas d'affichage
@@ -412,7 +412,7 @@ git pull
 
 # Réinstaller
 cd raspberry-pi-installer/scripts
-sudo ./main_orchestrator_v2.sh
+sudo ./install.sh
 ```
 
 Les principales corrections de la v2.3.0 :

--- a/raspberry-pi-installer/scripts/install-vm.sh
+++ b/raspberry-pi-installer/scripts/install-vm.sh
@@ -64,13 +64,13 @@ echo
 # Détecter quel script est disponible
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-if [[ -f "$SCRIPT_DIR/main_orchestrator_v2.sh" ]]; then
-    echo -e "${GREEN}Script v2.3.0 détecté${NC}"
-    echo "Lancement de l'installation avec choix du mode d'affichage..."
+if [[ -f "$SCRIPT_DIR/../install.sh" ]]; then
+    echo -e "${GREEN}Script d'installation détecté${NC}"
+    echo "Lancement de l'installation..."
     echo
-    exec "$SCRIPT_DIR/main_orchestrator_v2.sh" "$@"
+    exec "$SCRIPT_DIR/../install.sh" "$@"
 elif [[ -f "$SCRIPT_DIR/main_orchestrator.sh" ]]; then
-    echo -e "${GREEN}Script v2.2.0 détecté${NC}"
+    echo -e "${GREEN}Script legacy détecté${NC}"
     echo "Lancement de l'installation classique..."
     echo
     exec "$SCRIPT_DIR/main_orchestrator.sh" "$@"

--- a/raspberry-pi-installer/scripts/patches/allow-vm-installation.sh
+++ b/raspberry-pi-installer/scripts/patches/allow-vm-installation.sh
@@ -157,11 +157,11 @@ echo "Mode VM activé - Émulation Pi 4B 4GB"
 echo ""
 
 # Demander quel script lancer
-if [[ -f ./main_orchestrator_v2.sh ]]; then
-    echo "Lancement de l'installation v2.3.0..."
-    exec ./main_orchestrator_v2.sh "$@"
+if [[ -f ./install.sh ]]; then
+    echo "Lancement de l'installation..."
+    exec ./install.sh "$@"
 elif [[ -f ./main_orchestrator.sh ]]; then
-    echo "Lancement de l'installation v2.2.0..."
+    echo "Lancement de l'installation..."
     exec ./main_orchestrator.sh "$@"
 else
     echo "ERREUR: Aucun script d'installation trouvé"
@@ -203,7 +203,7 @@ main() {
     echo ""
     echo "2. Option manuelle :"
     echo "   - Le mode VM est activé"
-    echo "   - Lancez maintenant : sudo ./main_orchestrator_v2.sh"
+    echo "   - Lancez maintenant : sudo ./install.sh"
     echo ""
     echo "Note: Les optimisations Pi-spécifiques seront ignorées"
     echo ""


### PR DESCRIPTION
## Summary
- update installation docs to use `install.sh`
- drop references to `main_orchestrator.sh` and `main_orchestrator_v2.sh`
- adjust VM install scripts to launch `install.sh`

## Testing
- `find . -name "*.sh" -exec bash -n {} \;`
- `find web-interface -name "*.php" -exec php -l {} \;` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6862a664b2fc8326973f7f20542a9f8a