### PR TITLE
Fix video upload and show download logs

### DIFF
--- a/web-interface/assets/js/main.js
+++ b/web-interface/assets/js/main.js
@@ -236,12 +236,17 @@ function downloadYouTube() {
         if (data.success) {
             showNotification('Téléchargement terminé!', 'success');
             urlInput.value = '';
-            // Refresh video list
+            if (data.output) {
+                progressDiv.innerHTML = '<pre>' + data.output + '</pre>';
+            }
             if (typeof refreshVideoList === 'function') {
                 refreshVideoList();
             }
         } else {
             showNotification('Erreur: ' + data.message, 'error');
+            if (data.output) {
+                progressDiv.innerHTML = '<pre>' + data.output + '</pre>';
+            }
         }
     })
     .catch(error => {
@@ -249,7 +254,6 @@ function downloadYouTube() {
     })
     .finally(() => {
         downloadBtn.disabled = false;
-        progressDiv.style.display = 'none';
     });
 }
 


### PR DESCRIPTION
## Summary
- add robust video upload handling
- show yt-dlp output after download
- enable progress output when calling yt-dlp

## Testing
- `find . -name "*.sh" -exec bash -n {} \;`
- `find web-interface -name "*.php" -exec php -l {} \;` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862caa8dfdc832682b89d59cf19a2d7