### PR TITLE
Add playlist management page

### DIFF
--- a/web-interface/includes/config.template.php
+++ b/web-interface/includes/config.template.php
@@ -20,6 +20,7 @@ define('VIDEO_DIR', '/opt/videos');
 define('SCRIPTS_DIR', '/opt/scripts');
 define('LOG_DIR', '/var/log/pi-signage');
 define('PROGRESS_DIR', '/tmp/pi-signage-progress');
+define('PLAYLIST_FILE', '/var/www/pi-signage-player/api/playlist.json');
 define('WEB_ROOT', dirname(__DIR__));
 // binaire yt-dlp - utilise le wrapper pour éviter les problèmes de permissions
 define('YTDLP_BIN', 'sudo /opt/scripts/yt-dlp-wrapper.sh');

--- a/web-interface/includes/functions.php
+++ b/web-interface/includes/functions.php
@@ -395,3 +395,54 @@ function checkDiskSpace() {
         ]
     ];
 }
+
+/**
+ * Enregistrer une playlist personnalisée
+ */
+function savePlaylist(array $filenames) {
+    $videos = [];
+
+    foreach ($filenames as $name) {
+        $base = basename($name);
+        if (!isValidFilename($base)) {
+            continue;
+        }
+
+        $path = VIDEO_DIR . '/' . $base;
+        if (!file_exists($path)) {
+            continue;
+        }
+
+        $videos[] = [
+            'path' => '/videos/' . $base,
+            'name' => $base
+        ];
+    }
+
+    $playlist = [
+        'version' => '1.0',
+        'updated' => date('c'),
+        'videos' => $videos
+    ];
+
+    $json = json_encode($playlist, JSON_PRETTY_PRINT);
+    if ($json === false) {
+        return false;
+    }
+
+    $dir = dirname(PLAYLIST_FILE);
+    if (!is_dir($dir)) {
+        mkdir($dir, 0755, true);
+    }
+
+    if (file_put_contents(PLAYLIST_FILE, $json) === false) {
+        return false;
+    }
+
+    chmod(PLAYLIST_FILE, 0644);
+    @chown(PLAYLIST_FILE, 'www-data');
+
+    logActivity('PLAYLIST_SAVED', strval(count($videos)) . ' videos');
+
+    return true;
+}

--- a/web-interface/public/playlist.php
+++ b/web-interface/public/playlist.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Gestion de la playlist Pi Signage
+ */
+
+define('PI_SIGNAGE_WEB', true);
+require_once dirname(__DIR__) . '/includes/config.php';
+require_once dirname(__DIR__) . '/includes/auth.php';
+require_once dirname(__DIR__) . '/includes/functions.php';
+require_once dirname(__DIR__) . '/includes/security.php';
+
+requireAuth();
+setSecurityHeaders();
+
+$message = '';
+$messageType = '';
+
+$selectedVideos = [];
+if (file_exists(PLAYLIST_FILE)) {
+    $data = json_decode(file_get_contents(PLAYLIST_FILE), true);
+    if (!empty($data['videos'])) {
+        foreach ($data['videos'] as $v) {
+            if (isset($v['name'])) {
+                $selectedVideos[] = $v['name'];
+            }
+        }
+    }
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (validateCSRFToken($_POST['csrf_token'] ?? '')) {
+        $videos = array_map('basename', $_POST['videos'] ?? []);
+        $valid = [];
+        foreach ($videos as $video) {
+            if (isValidFilename($video)) {
+                $valid[] = $video;
+            }
+        }
+        if (savePlaylist($valid)) {
+            $message = 'Playlist enregistrée avec succès';
+            $messageType = 'success';
+            $selectedVideos = $valid;
+        } else {
+            $message = "Erreur lors de l'enregistrement";
+            $messageType = 'error';
+        }
+    } else {
+        $message = 'Erreur de sécurité';
+        $messageType = 'error';
+    }
+}
+
+$videos = listVideos();
+?>
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Playlist - Pi Signage</title>
+    <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body>
+<?php include dirname(__DIR__) . '/templates/navigation.php'; ?>
+
+<main class="container">
+    <h1>📑 Gestion de la Playlist</h1>
+
+    <?php if ($message): ?>
+        <div class="alert alert-<?= $messageType ?>"><?= htmlspecialchars($message) ?></div>
+    <?php endif; ?>
+
+    <form method="post">
+        <input type="hidden" name="csrf_token" value="<?= generateCSRFToken() ?>">
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Utiliser</th>
+                    <th>Fichier</th>
+                    <th>Taille</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($videos as $video): ?>
+                <tr>
+                    <td>
+                        <input type="checkbox" name="videos[]" value="<?= htmlspecialchars($video['name']) ?>" <?= in_array($video['name'], $selectedVideos, true) ? 'checked' : '' ?>>
+                    </td>
+                    <td><?= htmlspecialchars($video['name']) ?></td>
+                    <td><?= formatFileSize($video['size']) ?></td>
+                </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+        <button type="submit" class="btn btn-success">Enregistrer</button>
+    </form>
+</main>
+
+<script src="assets/js/main.js"></script>
+</body>
+</html>

--- a/web-interface/templates/navigation.php
+++ b/web-interface/templates/navigation.php
@@ -22,6 +22,9 @@ $currentPage = basename($_SERVER['PHP_SELF']);
         <li class="<?= $currentPage === 'videos.php' ? 'active' : '' ?>">
             <a href="videos.php">📹 Vidéos</a>
         </li>
+        <li class="<?= $currentPage === 'playlist.php' ? 'active' : '' ?>">
+            <a href="playlist.php">📑 Playlist</a>
+        </li>
         <li class="<?= $currentPage === 'settings.php' ? 'active' : '' ?>">
             <a href="settings.php">⚙️ Paramètres</a>
         </li>


### PR DESCRIPTION
## Summary
- allow configuring custom playlist
- define `PLAYLIST_FILE` in config
- save selected videos to playlist JSON
- add playlist page
- link playlist in navigation

## Testing
- `find web-interface -name "*.php" -exec php -l {} \;`
- `find . -name "*.sh" -exec bash -n {} \;`

------
https://chatgpt.com/codex/tasks/task_e_68632d0231488326a7d3e0a64dad4ae5